### PR TITLE
Claim a specific port without try other ports

### DIFF
--- a/lib/harbor.js
+++ b/lib/harbor.js
@@ -147,6 +147,8 @@ Harbor.prototype.claim = function (name, port, cb) {
       self.emit('claim', name, port);
       cb(null, port);
     });
+  } else {
+    return cb(new Error('No valid port.'));
   }
 };
 

--- a/lib/harbor.js
+++ b/lib/harbor.js
@@ -85,7 +85,7 @@ Object.defineProperty(Harbor.prototype, 'claimed',
 });
 
 /**
- * ### .claim (name, cb)
+ * ### _claim (name, cb)
  *
  * Find an available port from the pool of open
  * ports and claim it for a given name.
@@ -94,11 +94,11 @@ Object.defineProperty(Harbor.prototype, 'claimed',
  * @param {Function} callback
  * @cb {Error|null}
  * @cb {Number} claimed port
- * @name claim
- * @api public
+ * @name _claim
+ * @api private
  */
 
-Harbor.prototype.claim = function (name, cb) {
+function _claim(name, cb) {
   var self = this;
 
   if (this.ports[name]) {
@@ -111,6 +111,43 @@ Harbor.prototype.claim = function (name, cb) {
     self.emit('claim', name, port);
     cb(null, port);
   });
+};
+
+/**
+ * ### .claim (name, cb)
+ *
+ * Find an available port from the pool of open
+ * ports (or use a provided port) and claim it for a given name.
+ *
+ * @param {String} name
+ * @param {Number} [port]
+ * @param {Function} callback
+ * @cb {Error|null}
+ * @cb {Number} claimed port
+ * @name claim
+ * @api public
+ */
+
+Harbor.prototype.claim = function (name, port, cb) {
+  var self = this;
+
+  if ('function' === typeof port) {
+    return _claim.call(this, name, port);
+  }
+
+  var _port = parseInt(port, 10);
+  if (!isNaN(_port) && _port > 0) {
+    if (this.ports[name]) {
+      return cb(null, this.ports[name]);
+    }
+
+    checkPort.call(this, _port, _port, function (err, port) {
+      if (err) return cb(err);
+      self.ports[name] = port;
+      self.emit('claim', name, port);
+      cb(null, port);
+    });
+  }
 };
 
 /**
@@ -140,12 +177,18 @@ Harbor.prototype.release = function (name) {
  * Will attempt to connect to a given port. If success,
  * will disconnect and pass that number to a callback.
  *
- * @param {Object} range min/max
+ * @param {Number} num Port to check
+ * @param {Number} max Max port to check
  * @param {Function} callback
  */
 
-function checkPort (num, cb) {
+function checkPort (num, max, cb) {
   var self = this;
+
+  if ('function' === typeof max) {
+    cb = max;
+    max = this.max;
+  }
 
   // if already claimed, skip
   if (~this.claimed.indexOf(num)) {
@@ -158,7 +201,7 @@ function checkPort (num, cb) {
 
   // if error, we don't want this server
   server.on('error', function (err) {
-    if (num == self.max) {
+    if (num == max) {
       self.emit('full');
       return cb(new Error('No ports available in range.'));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harbor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TCP port availability and assignment utility.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harbor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TCP port availability and assignment utility.",
   "main": "index.js",
   "scripts": {

--- a/test/harbor.js
+++ b/test/harbor.js
@@ -59,6 +59,27 @@ describe('harbor', function () {
       finder.ports.should.not.have.property('http');
     });
 
+    it('can claim a specific port', function (done) {
+      var claim = chai.spy(function (name, port) {
+        name.should.equal('http');
+        port.should.equal(4300);
+      });
+
+      var full = chai.spy();
+
+      finder.on('claim', claim);
+      finder.on('full', full);
+
+      finder.claim('http', 4300, function (err, port) {
+        Should.not.exist(err);
+        port.should.equal(4300);
+        finder.ports.should.have.property('http', 4300);
+        finder.claimed.should.include(4300);
+        claim.should.have.been.called.once;
+        full.should.have.not.been.called();
+        done();
+      });
+    });
   });
 
   describe('when port not available', function () {


### PR DESCRIPTION
Sometimes it is useful to claim a specific port instead to find a free port inside the default range. For example a web server can try to start using port 80, but if it fails, it can try again using the first free port inside the default port range (or configured range).

Marcello
